### PR TITLE
async/batch-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 A Clojure library of utility functions.
 
+## core.async
+
+### `batch-process`
+
+`batch-process` takes from a channel and calls a function on sequences
+of messages from that channel. It is triggered every time the channel
+provides a batch of the given size, or every time the timeout elapses,
+whichever comes first.
+
+```clj
+(batch-process ch prn 4 1000)
+(async/onto-chan ch (range 10) false)
+(Thread/sleep 2000)
+(async/>!! ch 10)
+```
+
+That will end up printing:
+
+```
+[0 1 2 3]
+[4 5 6 7]
+[8 9]
+[10]
+```
+
 ## License
 
 Copyright © 2016 Democracy Works, Inc.

--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,5 @@
   :url "https://github.com/democracyworks/utility-works"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/core.async "0.2.391"]])

--- a/src/utility_works/async.clj
+++ b/src/utility_works/async.clj
@@ -14,7 +14,7 @@
                []))
       (a/alt!
         ch ([message]
-            (when message
+            (when-not (nil? message)
               (recur timeout-ch
                      (conj messages message))))
         timeout-ch (do

--- a/src/utility_works/async.clj
+++ b/src/utility_works/async.clj
@@ -1,0 +1,25 @@
+(ns utility-works.async
+  (:require [clojure.core.async :as a]))
+
+(defn batch-process [ch f batch-size timeout]
+  "Take from ch and call f on a seq of messages every batch-size
+  messages or every timeout milliseconds, whichever comes first."
+  (a/go-loop [timeout-ch (a/timeout timeout)
+              messages []]
+    (if (= batch-size (count messages))
+      (do
+        (a/thread
+          (f messages))
+        (recur (a/timeout timeout)
+               []))
+      (a/alt!
+        ch ([message]
+            (when message
+              (recur timeout-ch
+                     (conj messages message))))
+        timeout-ch (do
+                     (when (seq messages)
+                       (a/thread
+                         (f messages)))
+                     (recur (a/timeout timeout)
+                            []))))))

--- a/test/utility_works/async_test.clj
+++ b/test/utility_works/async_test.clj
@@ -1,0 +1,32 @@
+(ns utility-works.async-test
+  (:require [utility-works.async :refer :all]
+            [clojure.test :refer :all]
+            [clojure.core.async :as a]))
+
+(deftest batch-process-test
+  (testing "processes messages according to batch size and timeout"
+    (let [result (atom [])
+          messages (a/chan 100)]
+      (batch-process messages
+                     (partial swap! result conj)
+                     4
+                     100)
+
+      (a/onto-chan messages (range 10) false)
+      (Thread/sleep 120)
+      (a/>!! messages 10)
+      (Thread/sleep 120)
+      (a/onto-chan messages (range 10) false)
+      (Thread/sleep 240)
+      (a/>!! messages 10)
+      (Thread/sleep 120)
+
+      (is (= [[0 1 2 3]
+              [4 5 6 7]
+              [8 9]
+              [10]
+              [0 1 2 3]
+              [4 5 6 7]
+              [8 9]
+              [10]]
+             @result)))))


### PR DESCRIPTION
`batch-process` takes from a channel and calls a function on sequences of messages from that channel. It is triggered every time the channel provides a batch of the given size, or every time the timeout elapses, whichever comes first.