### PR TITLE
Batch processes wrapup fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ That will end up printing:
 [10]
 ```
 
+You may call `batch-process` with an optional 0-arity function which
+will be called when the channel has been closed and emptied.
+
 ## License
 
 Copyright © 2016 Democracy Works, Inc.

--- a/src/utility_works/async.clj
+++ b/src/utility_works/async.clj
@@ -1,25 +1,29 @@
 (ns utility-works.async
   (:require [clojure.core.async :as a]))
 
-(defn batch-process [ch f batch-size timeout]
+(defn batch-process
   "Take from ch and call f on a seq of messages every batch-size
   messages or every timeout milliseconds, whichever comes first."
-  (a/go-loop [timeout-ch (a/timeout timeout)
-              messages []]
-    (if (= batch-size (count messages))
-      (do
-        (a/thread
-          (f messages))
-        (recur (a/timeout timeout)
-               []))
-      (a/alt!
-        ch ([message]
-            (when-not (nil? message)
-              (recur timeout-ch
-                     (conj messages message))))
-        timeout-ch (do
-                     (when (seq messages)
-                       (a/thread
-                         (f messages)))
-                     (recur (a/timeout timeout)
-                            []))))))
+  ([ch f batch-size timeout]
+   (batch-process ch f batch-size timeout (constantly nil)))
+  ([ch f batch-size timeout wrapup-f]
+   (a/go-loop [timeout-ch (a/timeout timeout)
+               messages []]
+     (if (= batch-size (count messages))
+       (do
+         (a/thread
+           (f messages))
+         (recur (a/timeout timeout)
+                []))
+       (a/alt!
+         ch ([message]
+             (if (nil? message)
+               (wrapup-f)
+               (recur timeout-ch
+                      (conj messages message))))
+         timeout-ch (do
+                      (when (seq messages)
+                        (a/thread
+                          (f messages)))
+                      (recur (a/timeout timeout)
+                             [])))))))

--- a/src/utility_works/async.clj
+++ b/src/utility_works/async.clj
@@ -3,7 +3,9 @@
 
 (defn batch-process
   "Take from ch and call f on a seq of messages every batch-size
-  messages or every timeout milliseconds, whichever comes first."
+  messages or every timeout milliseconds, whichever comes first. An
+  optional wrapup-f will be called after ch has been closed and
+  emptied."
   ([ch f batch-size timeout]
    (batch-process ch f batch-size timeout (constantly nil)))
   ([ch f batch-size timeout wrapup-f]

--- a/test/utility_works/async_test.clj
+++ b/test/utility_works/async_test.clj
@@ -6,11 +6,17 @@
 (deftest batch-process-test
   (testing "processes messages according to batch size and timeout"
     (let [result (atom [])
+          timing (atom nil)
+          start-time (System/currentTimeMillis)
           messages (a/chan 100)]
       (batch-process messages
                      (partial swap! result conj)
                      4
-                     100)
+                     100
+                     (fn []
+                       (reset! timing
+                               (- (System/currentTimeMillis)
+                                  start-time))))
 
       (a/onto-chan messages (range 10) false)
       (Thread/sleep 120)
@@ -21,6 +27,8 @@
       (a/>!! messages 10)
       (Thread/sleep 120)
 
+      (a/close! messages)
+
       (is (= [[0 1 2 3]
               [4 5 6 7]
               [8 9]
@@ -29,4 +37,7 @@
               [4 5 6 7]
               [8 9]
               [10]]
-             @result)))))
+             @result))
+
+      (testing "calls the wrapup-f afterwards"
+        (is (< 600 @timing))))))


### PR DESCRIPTION
Adds an optional argument to `batch-process`: a 0-arity function that will be called once the channel is closed and empty. For cleanup work one might want to perform when the job is done.