### PR TITLE
Process last messages after channel close

### DIFF
--- a/src/utility_works/async.clj
+++ b/src/utility_works/async.clj
@@ -20,7 +20,10 @@
        (a/alt!
          ch ([message]
              (if (nil? message)
-               (wrapup-f)
+               (do
+                 (when (seq messages)
+                   (f messages))
+                 (wrapup-f))
                (recur timeout-ch
                       (conj messages message))))
          timeout-ch (do

--- a/test/utility_works/async_test.clj
+++ b/test/utility_works/async_test.clj
@@ -25,7 +25,6 @@
       (a/onto-chan messages (range 10) false)
       (Thread/sleep 240)
       (a/>!! messages 10)
-      (Thread/sleep 120)
 
       (a/close! messages)
 
@@ -40,4 +39,4 @@
              @result))
 
       (testing "calls the wrapup-f afterwards"
-        (is (< 600 @timing))))))
+        (is (< 480 @timing))))))


### PR DESCRIPTION
`messages` may contain messages once the channel being processed is closed. They should still have `f` called on them before `wrapup-f` is called.

The updated test shows that messages continue to be processed after the channel is closed if any have built up.